### PR TITLE
[bwd compat] default exit_status to None

### DIFF
--- a/src/tritongrader/autograder.py
+++ b/src/tritongrader/autograder.py
@@ -147,8 +147,10 @@ class Autograder:
         """
         return IOTestCaseBulkLoader(
             self,
-            commands_path=(commands_path or os.path.join(self.tests_path, "in")),
-            test_input_path=(test_input_path or os.path.join(self.tests_path, "in")),
+            commands_path=(commands_path or os.path.join(
+                self.tests_path, "in")),
+            test_input_path=(test_input_path or os.path.join(
+                self.tests_path, "in")),
             expected_stdout_path=(
                 expected_stdout_path or os.path.join(self.tests_path, "exp")
             ),
@@ -156,7 +158,8 @@ class Autograder:
                 expected_stderr_path or os.path.join(self.tests_path, "exp")
             ),
             expected_exit_status_path=(
-                expected_exit_status_path or os.path.join(self.tests_path, "exp")
+                expected_exit_status_path or os.path.join(
+                    self.tests_path, "exp")
             ),
             commands_prefix=commands_prefix,
             test_input_prefix=test_input_prefix,
@@ -175,7 +178,7 @@ class Autograder:
             shutil.copy2(path, dst)
             logger.info(f"Copied file from {path} to {dst}...")
         elif os.path.isdir(path):
-            shutil.copytree(path, dst)
+            shutil.copytree(path, dst, dir_exists_ok=True)
             logger.info(f"Copied directory from {path} to {dst}...")
 
     def copy_submission_files(self):
@@ -207,5 +210,6 @@ class Autograder:
         cwd = os.getcwd()
         os.chdir(self.sandbox.name)
         self._execute()
-        logger.info(f"Finished running {self.name} test(s). Returning to {cwd}")
+        logger.info(
+            f"Finished running {self.name} test(s). Returning to {cwd}")
         os.chdir(cwd)

--- a/src/tritongrader/autograder.py
+++ b/src/tritongrader/autograder.py
@@ -178,7 +178,7 @@ class Autograder:
             shutil.copy2(path, dst)
             logger.info(f"Copied file from {path} to {dst}...")
         elif os.path.isdir(path):
-            shutil.copytree(path, dst, dir_exists_ok=True)
+            shutil.copytree(path, dst, dirs_exist_ok=True)
             logger.info(f"Copied directory from {path} to {dst}...")
 
     def copy_submission_files(self):

--- a/src/tritongrader/test_case/io_test_case.py
+++ b/src/tritongrader/test_case/io_test_case.py
@@ -212,14 +212,15 @@ class IOTestCaseBulkLoader:
         stderr = os.path.join(
             self.expected_stderr_path, self.expected_stderr_prefix + name
         )
+
+        exit_status = None
         if self.expected_exit_status_path is not None and self.expected_exit_status_prefix is not None:
             file = os.path.join(
                 self.expected_exit_status_path, self.expected_exit_status_prefix + name
             )
-            with open(file, "r") as fin:
-                exit_status = int(fin.read().strip())
-        else:
-            exit_status = None
+            if os.path.exists(file):
+                with open(file, "r") as fin:
+                    exit_status = int(fin.read().strip())
 
         test_name = name if no_prefix else self.prefix + prefix + name
         test_case = IOTestCase(


### PR DESCRIPTION
`exit_status` defaults to `None` if no exit status file is provided. This is a backward compatibility patch.